### PR TITLE
fix: remove breaking @qwik-city-sw-register

### DIFF
--- a/app/qwik/src/preset.ts
+++ b/app/qwik/src/preset.ts
@@ -12,7 +12,7 @@ export const viteFinal: StorybookConfig['viteFinal'] = async (defaultConfig, opt
     build: {
       target: 'es2020',
       rollupOptions: {
-        external: ['@qwik-city-sw-register', '@qwik-city-plan'],
+        external: ['@qwik-city-plan'],
       },
     },
   });


### PR DESCRIPTION
Using @qwik-city-sw-register breaks static builds.

`TypeError: Failed to resolve module specifier "@qwik-city-sw-register". Relative references must start with either "/", "./", or "../".`

To reproduce, run `storybook build -s public` then open the static build for a runtime error. (i suggest using npm module `http-server`)

I haven't found a way to get it working with @qwik-city-sw-register, however, it shouldnt be necessary to have prefetching features with storybook and would be safe to remove.