### PR TITLE
Added autodocs generator

### DIFF
--- a/packages/qwik-app/.storybook/main.ts
+++ b/packages/qwik-app/.storybook/main.ts
@@ -10,7 +10,7 @@ const config: StorybookConfig = {
     renderer: 'storybook-framework-qwik',
   },
   docs: {
-    autodocs: false,
+    autodocs: "tag"
   },
   staticDirs: ['../public'],
 };

--- a/packages/qwik-app/.storybook/main.ts
+++ b/packages/qwik-app/.storybook/main.ts
@@ -10,7 +10,7 @@ const config: StorybookConfig = {
     renderer: 'storybook-framework-qwik',
   },
   docs: {
-    autodocs: "tag"
+    autodocs: 'tag',
   },
   staticDirs: ['../public'],
 };

--- a/packages/qwik-app/src/components/light-component/light-component.stories.tsx
+++ b/packages/qwik-app/src/components/light-component/light-component.stories.tsx
@@ -4,6 +4,7 @@ import { LightComponent } from './light-component';
 export default {
   title: 'Light Component',
   component: LightComponent,
+  tags: ['autodocs'],
 } as Meta<{}>;
 
 export const Default: StoryObj<{}> = {};

--- a/packages/qwik-lib/.storybook/main.ts
+++ b/packages/qwik-lib/.storybook/main.ts
@@ -9,7 +9,7 @@ const config = {
     name: 'storybook-framework-qwik',
   },
   docs: {
-    docsPage: true,
+    autodocs: "tag"
   },
 };
 

--- a/packages/qwik-lib/.storybook/main.ts
+++ b/packages/qwik-lib/.storybook/main.ts
@@ -9,7 +9,7 @@ const config = {
     name: 'storybook-framework-qwik',
   },
   docs: {
-    autodocs: "tag"
+    autodocs: 'tag',
   },
 };
 

--- a/packages/qwik-lib/src/components/counter/counter.stories.tsx
+++ b/packages/qwik-lib/src/components/counter/counter.stories.tsx
@@ -5,7 +5,7 @@ import { Counter, CounterProps } from './counter';
 export default {
   title: 'Counter',
   component: Counter,
-  tags: ["autodocs"],
+  tags: ['autodocs'],
 } satisfies Meta<CounterProps>;
 
 /** Test case: Should display this documentation */
@@ -16,9 +16,9 @@ export const Render: StoryObj<CounterProps> = {
   render: (args) => {
     return (
       <>
-        <Lite prop='Hello'/>
+        <Lite prop="Hello" />
         <Counter {...args} />
       </>
-    )
-  }
+    );
+  },
 };

--- a/packages/qwik-lib/src/components/counter/counter.stories.tsx
+++ b/packages/qwik-lib/src/components/counter/counter.stories.tsx
@@ -1,9 +1,24 @@
-import { Counter } from './counter';
+import { Meta, StoryObj } from '../../../../storybook-framework-qwik/dist';
+import { Lite } from '../lite/lite';
+import { Counter, CounterProps } from './counter';
 
 export default {
   title: 'Counter',
   component: Counter,
   tags: ["autodocs"],
-};
+} satisfies Meta<CounterProps>;
 
-export const Standard = {};
+/** Test case: Should display this documentation */
+export const Standard: StoryObj<CounterProps> = {};
+
+/** Test case: Should be able to render multiple components in same story */
+export const Render: StoryObj<CounterProps> = {
+  render: (args) => {
+    return (
+      <>
+        <Lite prop='Hello'/>
+        <Counter {...args} />
+      </>
+    )
+  }
+};

--- a/packages/qwik-lib/src/components/counter/counter.stories.tsx
+++ b/packages/qwik-lib/src/components/counter/counter.stories.tsx
@@ -3,6 +3,7 @@ import { Counter } from './counter';
 export default {
   title: 'Counter',
   component: Counter,
+  tags: ["autodocs"],
 };
 
 export const Standard = {};

--- a/packages/qwik-lib/src/components/counter/counter.tsx
+++ b/packages/qwik-lib/src/components/counter/counter.tsx
@@ -1,14 +1,76 @@
 import { component$, useStore } from '@builder.io/qwik';
 
-export const Counter = component$(() => {
-  const store = useStore({ count: 0 });
+export interface CounterProps {
+  /** Counter initial value */
+  initialValue?: number;
+  /** Increment counter by this value */
+  step?: number;
+}
 
+/** With docs */
+export const CONST = "Hello"
+
+/**
+ * Declare a Qwik component that can be used to create UI.
+ *
+ * Use `component$` to declare a Qwik component. A Qwik component is a special kind of component
+ * that allows the Qwik framework to lazy load and execute the component independently of other
+ * Qwik components as well as lazy load the component's life-cycle hooks and event handlers.
+ *
+ * Side note: You can also declare regular (standard JSX) components that will have standard
+ * synchronous behavior.
+ *
+ * Qwik component is a facade that describes how the component should be used without forcing the
+ * implementation of the component to be eagerly loaded. A minimum Qwik definition consists of:
+ *
+ * ### Example
+ *
+ * An example showing how to create a counter component:
+ *
+ * ```tsx
+ * export interface CounterProps {
+ *   initialValue?: number;
+ *   step?: number;
+ * }
+ * export const Counter = component$((props: CounterProps) => {
+ *   const state = useStore({ count: props.initialValue || 0 });
+ *   return (
+ *     <div>
+ *       <span>{state.count}</span>
+ *       <button onClick$={() => (state.count += props.step || 1)}>+</button>
+ *     </div>
+ *   );
+ * });
+ * ```
+ *
+ * - `component$` is how a component gets declared.
+ * - `{ value?: number; step?: number }` declares the public (props) interface of the component.
+ * - `{ count: number }` declares the private (state) interface of the component.
+ *
+ * The above can then be used like so:
+ *
+ * ```tsx
+ * export const OtherComponent = component$(() => {
+ *   return <Counter initialValue={100} />;
+ * });
+ * ```
+ *
+ * See also: `component`, `useCleanup`, `onResume`, `onPause`, `useOn`, `useOnDocument`,
+ * `useOnWindow`, `useStyles`
+ */
+export const Counter = component$((props: CounterProps) => {
+  const state = useStore({ count: props.initialValue || 0 });
   return (
     <div>
-      <p>Count: {store.count}</p>
-      <p>
-        <button onClick$={() => store.count++}>Increment</button>
-      </p>
+      <span>{state.count}</span>
+      <button onClick$={() => (state.count += props.step || 1)}>+</button>
     </div>
   );
 });
+
+/** Hello  */
+export const Lite = () => {
+  return (
+    <div>Hello</div>
+  )
+}

--- a/packages/qwik-lib/src/components/counter/counter.tsx
+++ b/packages/qwik-lib/src/components/counter/counter.tsx
@@ -67,7 +67,5 @@ export const Counter = component$((props: CounterProps) => {
 
 /** Component in the same file */
 export const SameFileComponent = () => {
-  return (
-    <div>SameFileComponent</div>
-  )
-}
+  return <div>SameFileComponent</div>;
+};

--- a/packages/qwik-lib/src/components/counter/counter.tsx
+++ b/packages/qwik-lib/src/components/counter/counter.tsx
@@ -7,9 +7,6 @@ export interface CounterProps {
   step?: number;
 }
 
-/** With docs */
-export const CONST = "Hello"
-
 /**
  * Declare a Qwik component that can be used to create UI.
  *
@@ -68,9 +65,9 @@ export const Counter = component$((props: CounterProps) => {
   );
 });
 
-/** Hello  */
-export const Lite = () => {
+/** Component in the same file */
+export const SameFileComponent = () => {
   return (
-    <div>Hello</div>
+    <div>SameFileComponent</div>
   )
 }

--- a/packages/qwik-lib/src/components/lite/lite.stories.tsx
+++ b/packages/qwik-lib/src/components/lite/lite.stories.tsx
@@ -3,15 +3,15 @@ import { Lite as AliasLite } from './lite';
 export default {
   title: 'Lite',
   component: AliasLite,
-  tags: ["autodocs"],
+  tags: ['autodocs'],
 };
 
 /** Test case: Override default value */
 export const Standard = {
   args: {
-    prop: "Non-default"
-  }
+    prop: 'Non-default',
+  },
 };
 
 /** Test case: Story with the same name as it's component */
-export const Lite = {}
+export const Lite = {};

--- a/packages/qwik-lib/src/components/lite/lite.stories.tsx
+++ b/packages/qwik-lib/src/components/lite/lite.stories.tsx
@@ -1,0 +1,17 @@
+import { Lite as AliasLite } from './lite';
+
+export default {
+  title: 'Lite',
+  component: AliasLite,
+  tags: ["autodocs"],
+};
+
+/** Test case: Override default value */
+export const Standard = {
+  args: {
+    prop: "Non-default"
+  }
+};
+
+/** Test case: Story with the same name as it's component */
+export const Lite = {}

--- a/packages/qwik-lib/src/components/lite/lite.tsx
+++ b/packages/qwik-lib/src/components/lite/lite.tsx
@@ -3,8 +3,6 @@ export interface LiteProps {
 }
 
 /** Lite component */
-export const Lite = ({ prop = "default" }: LiteProps) => {
-  return (
-    <div>Lite: {prop}</div>
-  )
-}
+export const Lite = ({ prop = 'default' }: LiteProps) => {
+  return <div>Lite: {prop}</div>;
+};

--- a/packages/qwik-lib/src/components/lite/lite.tsx
+++ b/packages/qwik-lib/src/components/lite/lite.tsx
@@ -1,0 +1,10 @@
+export interface LiteProps {
+  prop: string;
+}
+
+/** Lite component */
+export const Lite = ({ prop = "default" }: LiteProps) => {
+  return (
+    <div>Lite: {prop}</div>
+  )
+}

--- a/packages/storybook-framework-qwik/package.json
+++ b/packages/storybook-framework-qwik/package.json
@@ -81,7 +81,11 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "@storybook/builder-vite": ">=7.0.0-beta.7"
+    "@storybook/builder-vite": ">=7.0.0-beta.7",
+    "@storybook/docs-tools": ">=7.0.0-beta.7",
+    "@storybook/types": ">=7.0.0-beta.7",
+    "magic-string": "^0.30.0",
+    "react-docgen-typescript": "^2.2.2"
   },
   "peerDependencies": {
     "@builder.io/qwik": ">=0.15.2"

--- a/packages/storybook-framework-qwik/src/component-to-jsx.tsx
+++ b/packages/storybook-framework-qwik/src/component-to-jsx.tsx
@@ -1,6 +1,0 @@
-import { FunctionComponent } from '@builder.io/qwik';
-import { Args } from './types.js';
-
-export const componentToJSX = (Component: FunctionComponent, args: Args) => {
-  return <Component {...args} />;
-};

--- a/packages/storybook-framework-qwik/src/component-to-jsx.tsx
+++ b/packages/storybook-framework-qwik/src/component-to-jsx.tsx
@@ -1,0 +1,6 @@
+import { FunctionComponent } from '@builder.io/qwik';
+import { Args } from './types.js';
+
+export const componentToJSX = (Component: FunctionComponent, args: Args) => {
+  return <Component {...args} />;
+};

--- a/packages/storybook-framework-qwik/src/docs/config.ts
+++ b/packages/storybook-framework-qwik/src/docs/config.ts
@@ -10,7 +10,7 @@ function getComponentName(component: FunctionComponent): string {
 
 function getComponentDoc(component: FunctionComponent): ComponentDoc {
   const displayName = getComponentName(component);
-  return parent.__STORYBOOK_COMPONENT_DOC__.find((componentDoc) => componentDoc.displayName  === displayName);
+  return window.__STORYBOOK_COMPONENT_DOC__.get(displayName);
 }
 
 function extractComponentDescription(component: FunctionComponent): string {
@@ -30,11 +30,11 @@ function extractArgTypes(component: FunctionComponent): StrictArgTypes {
       },
       table: {
         type: {
-            summary: value.type.name,
-            required: value.required,
+          summary: value.type.name,
+          required: value.required,
         },
         defaultValue: {
-            summary: value.defaultValue,
+          summary: value.defaultValue?.value,
         }
       }
     }

--- a/packages/storybook-framework-qwik/src/docs/config.ts
+++ b/packages/storybook-framework-qwik/src/docs/config.ts
@@ -1,0 +1,53 @@
+import type { FunctionComponent } from '@builder.io/qwik';
+import type { StrictArgTypes } from '@storybook/types';
+import { enhanceArgTypes, convert } from '@storybook/docs-tools';
+import { ComponentDoc } from 'react-docgen-typescript';
+
+function getComponentName(component: FunctionComponent): string {
+  if (component.name === "QwikComponent") return component({}, "", 0).props["q:renderFn"].dev.displayName.replace("_component", "");
+  return component.name;
+}
+
+function getComponentDoc(component: FunctionComponent): ComponentDoc {
+  const displayName = getComponentName(component);
+  return parent.__STORYBOOK_COMPONENT_DOC__.find((componentDoc) => componentDoc.displayName  === displayName);
+}
+
+function extractComponentDescription(component: FunctionComponent): string {
+  return getComponentDoc(component)?.description;
+}
+
+function extractArgTypes(component: FunctionComponent): StrictArgTypes {
+  const componentDoc = getComponentDoc(component);
+  if (!componentDoc) return undefined;
+  const strictArgTypes: StrictArgTypes = {};
+  Object.entries(componentDoc.props).forEach(([key, value]) => {
+    strictArgTypes[key] = {
+      ...value,
+      type: {
+        required: value.required,
+        ...convert(value)
+      },
+      table: {
+        type: {
+            summary: value.type.name,
+            required: value.required,
+        },
+        defaultValue: {
+            summary: value.defaultValue,
+        }
+      }
+    }
+  })
+  return strictArgTypes;
+}
+
+export const parameters = {
+  docs: {
+    story: { inline: true },
+    extractArgTypes,
+    extractComponentDescription,
+  },
+};
+
+export const argTypesEnhancers = [enhanceArgTypes];

--- a/packages/storybook-framework-qwik/src/docs/qwik-docgen.ts
+++ b/packages/storybook-framework-qwik/src/docs/qwik-docgen.ts
@@ -1,37 +1,29 @@
 import { parse } from "react-docgen-typescript";
 import type { PluginOption } from 'vite';
-import { createFilter } from 'vite';
 import MagicString from 'magic-string';
 
-export function qwikDocgen(): PluginOption {
-    // Naive way to include files containing Qwik component (by excluding stories).
-    // Will not work with files named 'story' or something else.
-    const isComponent = /^(?!.*\.stories\.tsx$).*\.tsx$/;
-  
-    return {
-      name: 'storybook:qwik-docgen-plugin',
-      async transform(src, id) {
-        if (createFilter(isComponent)(id)) {
-          const metaData = parse(id, {
-            propFilter: {
-              // Ignore Qwik internal props
-              skipPropsWithName: ["key", "q:slot"]
-            }
-          });
-          
-          const metaSource = JSON.stringify(metaData);
-  
-          const s = new MagicString.default(src);
-  
-          // Storying the component docs as a window property so we can reference it later while rendering the story.
-          // Using the same implementation as official Vue docgen plugin: https://github.com/storybookjs/storybook/blob/next/code/frameworks/vue-vite/src/plugins/vue-docgen.ts
-          s.append(`parent.window.__STORYBOOK_COMPONENT_DOC__ = ${metaSource}`);
-    
-          return {
-            code: s.toString(),
-            map: s.generateMap({ hires: true, source: id }),
-          };
+export function qwikDocgen(storyFilePaths: Array<string>): PluginOption {
+  return {
+    name: 'storybook:qwik-docgen-plugin',
+    async transform(src, id) {
+      const isComponent = id.endsWith(".tsx") && !storyFilePaths.some((storyFilePath) => id.endsWith(storyFilePath));
+      if (isComponent) {
+        const componentDocs = parse(id, {
+          propFilter: {
+            // Ignore Qwik internal props
+            skipPropsWithName: ["key", "q:slot"]
+          }
+        });
+        const s = new MagicString.default(src);
+        s.append(`window.__STORYBOOK_COMPONENT_DOC__ ??= new Map();`);
+        componentDocs.forEach((componentDoc) =>
+          s.append(`window.__STORYBOOK_COMPONENT_DOC__.set("${componentDoc.displayName}", ${JSON.stringify(componentDoc)});`)
+        );
+        return {
+          code: s.toString(),
+          map: s.generateMap({ hires: true, source: id }),
         };
-      },
-    };
+      }
+    },
+  };
 }

--- a/packages/storybook-framework-qwik/src/docs/qwik-docgen.ts
+++ b/packages/storybook-framework-qwik/src/docs/qwik-docgen.ts
@@ -1,0 +1,37 @@
+import { parse } from "react-docgen-typescript";
+import type { PluginOption } from 'vite';
+import { createFilter } from 'vite';
+import MagicString from 'magic-string';
+
+export function qwikDocgen(): PluginOption {
+    // Naive way to include files containing Qwik component (by excluding stories).
+    // Will not work with files named 'story' or something else.
+    const isComponent = /^(?!.*\.stories\.tsx$).*\.tsx$/;
+  
+    return {
+      name: 'storybook:qwik-docgen-plugin',
+      async transform(src, id) {
+        if (createFilter(isComponent)(id)) {
+          const metaData = parse(id, {
+            propFilter: {
+              // Ignore Qwik internal props
+              skipPropsWithName: ["key", "q:slot"]
+            }
+          });
+          
+          const metaSource = JSON.stringify(metaData);
+  
+          const s = new MagicString.default(src);
+  
+          // Storying the component docs as a window property so we can reference it later while rendering the story.
+          // Using the same implementation as official Vue docgen plugin: https://github.com/storybookjs/storybook/blob/next/code/frameworks/vue-vite/src/plugins/vue-docgen.ts
+          s.append(`parent.window.__STORYBOOK_COMPONENT_DOC__ = ${metaSource}`);
+    
+          return {
+            code: s.toString(),
+            map: s.generateMap({ hires: true, source: id }),
+          };
+        };
+      },
+    };
+}

--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -8,7 +8,7 @@ export const core: StorybookViteConfig['core'] = {
   renderer: 'storybook-framework-qwik',
 };
 
-export const viteFinal: StorybookViteConfig['viteFinal'] = async (defaultConfig, options) => {
+export const viteFinal: StorybookViteConfig['viteFinal'] = async (defaultConfig) => {
   const config = mergeConfig(defaultConfig, {
     build: {
       target: 'es2020',
@@ -18,15 +18,15 @@ export const viteFinal: StorybookViteConfig['viteFinal'] = async (defaultConfig,
     },
   });
 
-  // Add docgen plugin
   if (!config.plugins.some((plugin: Plugin) => plugin.name === "storybook:qwik-docgen-plugin"))
-    config.plugins.push(qwikDocgen());
+    config.plugins.push(qwikDocgen(defaultConfig.optimizeDeps.entries as Array<string>));
 
   // Qwik-city plugin may be used in apps, but it has mdx stuff that conflicts with Storybook mdx
   // we'll try to only remove the transform code (where the mdx stuff is), and keep everything else.
   config.plugins = config.plugins.map((plugin: Plugin) =>
     plugin.name === 'vite-plugin-qwik-city' ? { ...plugin, transform: () => null as any } : plugin
   );
+  
   return config;
 };
 

--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -1,6 +1,7 @@
 import type { StorybookViteConfig } from '@storybook/builder-vite';
-import { mergeConfig } from 'vite';
+import { mergeConfig, Plugin } from 'vite';
 import { QWIK_LOADER } from '@builder.io/qwik/loader';
+import { qwikDocgen } from './docs/qwik-docgen.js';
 
 export const core: StorybookViteConfig['core'] = {
   builder: '@storybook/builder-vite',
@@ -16,9 +17,14 @@ export const viteFinal: StorybookViteConfig['viteFinal'] = async (defaultConfig,
       },
     },
   });
+
+  // Add docgen plugin
+  if (!config.plugins.some((plugin: Plugin) => plugin.name === "storybook:qwik-docgen-plugin"))
+    config.plugins.push(qwikDocgen());
+
   // Qwik-city plugin may be used in apps, but it has mdx stuff that conflicts with Storybook mdx
   // we'll try to only remove the transform code (where the mdx stuff is), and keep everything else.
-  config.plugins = config.plugins.map((plugin: any) =>
+  config.plugins = config.plugins.map((plugin: Plugin) =>
     plugin.name === 'vite-plugin-qwik-city' ? { ...plugin, transform: () => null as any } : plugin
   );
   return config;

--- a/packages/storybook-framework-qwik/src/preview.ts
+++ b/packages/storybook-framework-qwik/src/preview.ts
@@ -1,14 +1,17 @@
 import { render as renderQwik } from '@builder.io/qwik';
 import { ArgsStoryFn, RenderContext } from '@storybook/types';
-import { componentToJSX } from './component-to-jsx.js';
 import { QwikRenderer } from './types.js';
+export { parameters, argTypesEnhancers } from "./docs/config.js"
 
 // returns the Qwik component as a JSX element (</MyComponent>)
 // If a story has a custom renderer, it will replace this function.
 export const render: ArgsStoryFn<QwikRenderer<unknown>> = (args, context) => {
   const { component } = context;
   if (typeof component === 'function') {
-    return componentToJSX(component, args);
+    // NEEDS REVIEW: When using 'componentToJSX' the component prop values will not update when value is changed
+    // inside the Storybook controls so I changed it back to the original and ensured a flag value is passed to function.
+    // I'm not sure exactly what 'flags' are but have not detected any changes in behavior after this change.
+    return component(args, context.name, 0);
   }
   return component;
 };

--- a/packages/storybook-framework-qwik/src/preview.ts
+++ b/packages/storybook-framework-qwik/src/preview.ts
@@ -1,6 +1,7 @@
 import { render as renderQwik } from '@builder.io/qwik';
 import { ArgsStoryFn, RenderContext } from '@storybook/types';
 import { QwikRenderer } from './types.js';
+import { componentToJSX } from './component-to-jsx.js';
 export { parameters, argTypesEnhancers } from "./docs/config.js"
 
 // returns the Qwik component as a JSX element (</MyComponent>)
@@ -8,10 +9,7 @@ export { parameters, argTypesEnhancers } from "./docs/config.js"
 export const render: ArgsStoryFn<QwikRenderer<unknown>> = (args, context) => {
   const { component } = context;
   if (typeof component === 'function') {
-    // NEEDS REVIEW: When using 'componentToJSX' the component prop values will not update when value is changed
-    // inside the Storybook controls so I changed it back to the original and ensured a flag value is passed to function.
-    // I'm not sure exactly what 'flags' are but have not detected any changes in behavior after this change.
-    return component(args, context.name, 0);
+    return componentToJSX(component, args);
   }
   return component;
 };
@@ -24,7 +22,6 @@ export async function renderToCanvas<T>(
   await renderQwik(container, storyFn());
   canvasElement.childNodes.forEach((c) => c.remove());
   canvasElement.append(container);
-
   showMain();
 }
 

--- a/packages/storybook-framework-qwik/src/typings.d.ts
+++ b/packages/storybook-framework-qwik/src/typings.d.ts
@@ -2,6 +2,6 @@ import type { ComponentDoc } from 'react-docgen-typescript';
 
 declare global {
   interface Window {
-    __STORYBOOK_COMPONENT_DOC__: Array<ComponentDoc>;
+    __STORYBOOK_COMPONENT_DOC__: Map<string, ComponentDoc>;
   }
 }

--- a/packages/storybook-framework-qwik/src/typings.d.ts
+++ b/packages/storybook-framework-qwik/src/typings.d.ts
@@ -1,1 +1,7 @@
-declare module 'global';
+import type { ComponentDoc } from 'react-docgen-typescript';
+
+declare global {
+  interface Window {
+    __STORYBOOK_COMPONENT_DOC__: Array<ComponentDoc>;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,6 +4113,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channel-postmessage@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/channel-postmessage@npm:7.0.0"
+  dependencies:
+    "@storybook/channels": 7.0.0
+    "@storybook/client-logger": 7.0.0
+    "@storybook/core-events": 7.0.0
+    "@storybook/global": ^5.0.0
+    qs: ^6.10.0
+    telejson: ^7.0.3
+  checksum: bfee3b79af1ac47a189b5571f779136afd2add69f66df96c51c6aa0e54deec1e88747eb4cc747cf9f014633fde813cea50a36134aed411cf432af78161d998ec
+  languageName: node
+  linkType: hard
+
 "@storybook/channel-postmessage@npm:7.0.0-beta.28":
   version: 7.0.0-beta.28
   resolution: "@storybook/channel-postmessage@npm:7.0.0-beta.28"
@@ -4150,6 +4164,13 @@ __metadata:
     "@storybook/global": ^5.0.0
     telejson: ^7.0.3
   checksum: e224ebbb9c655d4738f11385380ce86bb4323d8d94e38267104ed59d3987e1b482e55791264a9d353d7abe60cf85b4fdd1d6b7f61ec0a2ba358b6ca35988c3ae
+  languageName: node
+  linkType: hard
+
+"@storybook/channels@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/channels@npm:7.0.0"
+  checksum: 69aaa961e56464fffe2bad067e5bb68f7b6b4bab1be82fb39160291f100f699e260dfeea55f6f4a5aa4212005d53deaec2f7ca245042c4adb46fe09ee7aabb8f
   languageName: node
   linkType: hard
 
@@ -4213,6 +4234,15 @@ __metadata:
     getstorybook: bin/index.js
     sb: bin/index.js
   checksum: c2925ebf78e7b9cd23cca7d7eded5d4ba6bb3e8446a3ec060a1c182e6cc12e959d4c599496d3bbf63aa7e336dff7ef65365e128ec08b3542ec5c690576008008
+  languageName: node
+  linkType: hard
+
+"@storybook/client-logger@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/client-logger@npm:7.0.0"
+  dependencies:
+    "@storybook/global": ^5.0.0
+  checksum: 455218fe4e1556dcbf9981db52ce8d5bd8eb98f1e55e5e9628bf69c492b5bf8015266eb0b0baa9c4c5d3e3a466167196bd12ce097ad7a7e5d06f48d23a96811b
   languageName: node
   linkType: hard
 
@@ -4314,6 +4344,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/core-common@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/core-common@npm:7.0.0"
+  dependencies:
+    "@storybook/node-logger": 7.0.0
+    "@storybook/types": 7.0.0
+    "@types/node": ^16.0.0
+    "@types/pretty-hrtime": ^1.0.0
+    chalk: ^4.1.0
+    esbuild: ^0.17.0
+    esbuild-register: ^3.4.0
+    file-system-cache: ^2.0.0
+    find-up: ^5.0.0
+    fs-extra: ^11.1.0
+    glob: ^8.1.0
+    glob-promise: ^6.0.2
+    handlebars: ^4.7.7
+    lazy-universal-dotenv: ^4.0.0
+    picomatch: ^2.3.0
+    pkg-dir: ^5.0.0
+    pretty-hrtime: ^1.0.3
+    resolve-from: ^5.0.0
+    ts-dedent: ^2.0.0
+  checksum: af9c2fc13617aeb85a477a2940f3f4e82b79724a1cf4402d3951562085441d14d522b680d5d9eb067d1dfd4d14651233835fac04d14f74f536dfb4a29210d08e
+  languageName: node
+  linkType: hard
+
 "@storybook/core-common@npm:7.0.0-rc.8":
   version: 7.0.0-rc.8
   resolution: "@storybook/core-common@npm:7.0.0-rc.8"
@@ -4339,6 +4396,13 @@ __metadata:
     slash: ^3.0.0
     ts-dedent: ^2.0.0
   checksum: 2aff84015ec95a871b3fbe42ba86c3fa9306a00b644e9d72403e1f881b00f6b981bde56e29c7d77b59240116a815eb6e58032dc454552caf59a04225b661c835
+  languageName: node
+  linkType: hard
+
+"@storybook/core-events@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/core-events@npm:7.0.0"
+  checksum: fac4dd2aa410696ed3dd4b24a739cb5adc230aa7615b8c3bae7f1ed6b2deb365dcc1c19d54df7eb2f69e467bb7a339c7d0c350e2746afde627dd885e41ca702f
   languageName: node
   linkType: hard
 
@@ -4489,6 +4553,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/docs-tools@npm:>=7.0.0-beta.7":
+  version: 7.0.0
+  resolution: "@storybook/docs-tools@npm:7.0.0"
+  dependencies:
+    "@babel/core": ^7.12.10
+    "@storybook/core-common": 7.0.0
+    "@storybook/preview-api": 7.0.0
+    "@storybook/types": 7.0.0
+    "@types/doctrine": ^0.0.3
+    doctrine: ^3.0.0
+    lodash: ^4.17.21
+  checksum: ea5f4032f6b275adba2531c87abc9ec5e636ac3d7067c2ca649f0d93776985d43dd11f0bb31cdfd4651a92a6e4d6c1a8cd0e129024343f4066619522028ba42d
+  languageName: node
+  linkType: hard
+
 "@storybook/expect@storybook-jest":
   version: 27.5.2-0
   resolution: "@storybook/expect@npm:27.5.2-0"
@@ -4584,6 +4663,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/node-logger@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/node-logger@npm:7.0.0"
+  dependencies:
+    "@types/npmlog": ^4.1.2
+    chalk: ^4.1.0
+    npmlog: ^5.0.1
+    pretty-hrtime: ^1.0.3
+  checksum: 20b4990ad7991398545debdd155fc342869982679ff26619722dae70d57839aaf5d99a9d301e570d10ca6a2e54efadfa1ea0fd816a3987d97682c9bf98c6b540
+  languageName: node
+  linkType: hard
+
 "@storybook/node-logger@npm:7.0.0-beta.28":
   version: 7.0.0-beta.28
   resolution: "@storybook/node-logger@npm:7.0.0-beta.28"
@@ -4612,6 +4703,29 @@ __metadata:
   version: 7.0.0-rc.8
   resolution: "@storybook/postinstall@npm:7.0.0-rc.8"
   checksum: 5f98499ec45a149f43f04bc010d584a4b9d83babc10059911d7b69ce3f701adaab4c938dbf84764097956efc8f85d9e58ec64c3971af75ca4360fabc3a85259a
+  languageName: node
+  linkType: hard
+
+"@storybook/preview-api@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@storybook/preview-api@npm:7.0.0"
+  dependencies:
+    "@storybook/channel-postmessage": 7.0.0
+    "@storybook/channels": 7.0.0
+    "@storybook/client-logger": 7.0.0
+    "@storybook/core-events": 7.0.0
+    "@storybook/csf": next
+    "@storybook/global": ^5.0.0
+    "@storybook/types": 7.0.0
+    "@types/qs": ^6.9.5
+    dequal: ^2.0.2
+    lodash: ^4.17.21
+    memoizerific: ^1.11.3
+    qs: ^6.10.0
+    synchronous-promise: ^2.0.15
+    ts-dedent: ^2.0.0
+    util-deprecate: ^1.0.2
+  checksum: 2fcc973bfb9c44512d8c8eec4dd7d92e3a79ab3bd6f97d78cefe84dd4b5ffb4cb97cd7b363be0548a15dd0e77903a67d9a1b570326b0ddadc359a121c5032ef4
   languageName: node
   linkType: hard
 
@@ -4776,6 +4890,18 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 4f33c4350f83e7f59501dae98c63cd1541c8a29a494aa0a6a8cae7cfd2ea133f507e97c780d9a5a9384d1d65a75a645033f55b1f4faa09b89fc8b0bb50e3f1f4
+  languageName: node
+  linkType: hard
+
+"@storybook/types@npm:7.0.0, @storybook/types@npm:>=7.0.0-beta.7":
+  version: 7.0.0
+  resolution: "@storybook/types@npm:7.0.0"
+  dependencies:
+    "@storybook/channels": 7.0.0
+    "@types/babel__core": ^7.0.0
+    "@types/express": ^4.7.0
+    file-system-cache: ^2.0.0
+  checksum: 0409347a9b377216090398f48ec65917df82e47505546107d324eee18c58ac66178d327368da5ea3fd34fc3476c84793b5e572de70b05701858702a05bbaea6c
   languageName: node
   linkType: hard
 
@@ -13894,6 +14020,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.0":
+  version: 0.30.0
+  resolution: "magic-string@npm:0.30.0"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.13
+  checksum: 7bdf22e27334d8a393858a16f5f840af63a7c05848c000fd714da5aa5eefa09a1bc01d8469362f25cc5c4a14ec01b46557b7fff8751365522acddf21e57c488d
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^2.0.0, make-dir@npm:^2.1.0":
   version: 2.1.0
   resolution: "make-dir@npm:2.1.0"
@@ -17160,6 +17295,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-docgen-typescript@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "react-docgen-typescript@npm:2.2.2"
+  peerDependencies:
+    typescript: ">= 4.3.x"
+  checksum: a9826459ea44e818f21402728dd47f5cae60bd936574cefd4f90ad101ff3eebacd67b6e017b793309734ce62c037aa3072dbc855d2b0e29bad1a38cbf5bac115
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-dom@npm:18.2.0"
@@ -18624,8 +18768,12 @@ __metadata:
   dependencies:
     "@builder.io/qwik-city": ">=0.0.128"
     "@storybook/builder-vite": ">=7.0.0-beta.7"
+    "@storybook/docs-tools": ">=7.0.0-beta.7"
+    "@storybook/types": ">=7.0.0-beta.7"
     "@suin/semantic-release-yarn": 1.1.0
     "@types/node": ^18
+    magic-string: ^0.30.0
+    react-docgen-typescript: ^2.2.2
     semantic-release: ^21.0.0
     typescript: ~5.0.2
     vite: ^4.2.1
@@ -19547,11 +19695,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>, typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
   version: 5.0.2
-  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
+  checksum: b63cb742fbb9aeb3085e002ad8f10d5fd963606aa4d6b3b65b4e76c396ff09739f03b5dbae08e1698c3bce9d5619d3f67aeb7ee470ed4016bd345b3cfe37b54a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19695,11 +19695,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>, typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
   version: 5.0.2
-  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=1f5320"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: b63cb742fbb9aeb3085e002ad8f10d5fd963606aa4d6b3b65b4e76c396ff09739f03b5dbae08e1698c3bce9d5619d3f67aeb7ee470ed4016bd345b3cfe37b54a
+  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Will now generate documentation for components and properties automatically. Has followed official [Storybook Vue Docs Plugin](https://github.com/storybookjs/storybook/tree/fa16ccb5188fff9af3d23bef5b3f524653698b03/code/renderers/vue3/src/docs).

As it turns out, we can use [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) for Qwik components.

**Before**

<img width="1035" alt="Skärmavbild 2023-04-01 kl  09 42 02" src="https://user-images.githubusercontent.com/9481000/229355519-9f43ea68-8253-4623-ae9c-f68960d5ca0c.png">

**After**

<img width="1292" alt="Skärmavbild 2023-04-02 kl  15 16 29" src="https://user-images.githubusercontent.com/9481000/229355527-77ef61f8-b064-4632-a9a7-5dce295d10bd.png">
