### PR TITLE
fix: resolve builder and renderer path

### DIFF
--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -4,7 +4,8 @@ import { qwikDocgen } from "./docs/qwik-docgen.js";
 import { StorybookConfig } from "./types.js";
 import { dirname, join } from "path";
 
-const wrapForPnP = (input: string) => dirname(require.resolve(join(input, 'package.json')));
+const wrapForPnP = (input: string) =>
+  dirname(require.resolve(join(input, "package.json")));
 
 export const core: StorybookConfig["core"] = {
   builder: wrapForPnP("@storybook/builder-vite"),

--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -1,14 +1,17 @@
-import type { StorybookViteConfig } from "@storybook/builder-vite";
 import { mergeConfig, Plugin } from "vite";
 import { QWIK_LOADER } from "@builder.io/qwik/loader";
 import { qwikDocgen } from "./docs/qwik-docgen.js";
+import { StorybookConfig } from "./types.js";
+import { dirname, join } from "path";
 
-export const core: StorybookViteConfig["core"] = {
-  builder: "@storybook/builder-vite",
-  renderer: "storybook-framework-qwik",
+const wrapForPnP = (input: string) => dirname(require.resolve(join(input, 'package.json')));
+
+export const core: StorybookConfig["core"] = {
+  builder: wrapForPnP("@storybook/builder-vite"),
+  renderer: wrapForPnP("storybook-framework-qwik"),
 };
 
-export const viteFinal: StorybookViteConfig["viteFinal"] = async (
+export const viteFinal: StorybookConfig["viteFinal"] = async (
   defaultConfig
 ) => {
   const config = mergeConfig(defaultConfig, {
@@ -38,7 +41,7 @@ export const viteFinal: StorybookViteConfig["viteFinal"] = async (
   return config;
 };
 
-export const previewAnnotations: StorybookViteConfig["previewAnnotations"] = (
+export const previewAnnotations: StorybookConfig["previewAnnotations"] = (
   entry = []
 ) => [...entry, require.resolve("storybook-framework-qwik/preview.js")];
 

--- a/packages/storybook-framework-qwik/src/types.ts
+++ b/packages/storybook-framework-qwik/src/types.ts
@@ -1,4 +1,5 @@
 import { Component } from "@builder.io/qwik";
+import { StorybookConfigVite } from "@storybook/builder-vite";
 import { WebRenderer } from "@storybook/types";
 export type { Args, ArgTypes, Parameters, StrictArgs } from "@storybook/types";
 import type {
@@ -65,4 +66,4 @@ export type StoryContext<TArgs = StrictArgs> = GenericStoryContext<
 
 export type StorybookConfig = Omit<StorybookConfigBase, "framework"> & {
   framework: "storybook-framework-qwik" | { name: "storybook-framework-qwik" };
-};
+} & StorybookConfigVite;


### PR DESCRIPTION
this better supports situations where storybook core is hoisted in a different way than the builder package.