### PR TITLE
Move @storybook/types to devdependencies

### DIFF
--- a/packages/storybook-framework-qwik/package.json
+++ b/packages/storybook-framework-qwik/package.json
@@ -85,7 +85,6 @@
   "dependencies": {
     "@storybook/builder-vite": ">=7.0.0",
     "@storybook/docs-tools": ">=7.0.0",
-    "@storybook/types": ">=7.0.0",
     "magic-string": "^0.30.0",
     "react-docgen-typescript": "^2.2.2"
   },
@@ -96,6 +95,7 @@
     "@builder.io/qwik-city": "^1.1.4"
   },
   "devDependencies": {
+    "@storybook/types": ">=7.0.0",
     "@suin/semantic-release-yarn": "1.1.0",
     "@types/node": "^18.16.16",
     "semantic-release": "^21.0.2",

--- a/packages/storybook-framework-qwik/src/docs/config.ts
+++ b/packages/storybook-framework-qwik/src/docs/config.ts
@@ -1,4 +1,4 @@
-import type { StrictArgTypes } from "@storybook/types";
+import type { ArgTypesEnhancer, StrictArgTypes } from "@storybook/types";
 import { enhanceArgTypes, convert } from "@storybook/docs-tools";
 import { ComponentDoc } from "react-docgen-typescript";
 
@@ -48,4 +48,4 @@ export const parameters = {
   },
 };
 
-export const argTypesEnhancers = [enhanceArgTypes];
+export const argTypesEnhancers: ArgTypesEnhancer[] = [enhanceArgTypes];


### PR DESCRIPTION
[@storybook/types ](https://github.com/storybookjs/storybook/tree/next/code/lib/types) exports TS interfaces/types/enums only, and it should be marked as a devdependency.