### PR TITLE
fix: add ESM/CommonJS interop for require in Storybook preset

### DIFF
--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -3,7 +3,9 @@ import { QWIK_LOADER } from "@builder.io/qwik/loader";
 import { qwikDocgen } from "./docs/qwik-docgen.js";
 import { StorybookConfig } from "./types.js";
 import { dirname, join } from "path";
+import { createRequire } from "module";
 
+const require = createRequire(import.meta.url);
 const wrapForPnP = (input: string) =>
   dirname(require.resolve(join(input, "package.json")));
 


### PR DESCRIPTION
Some environments are treating the storybook-framework-qwik preset as an ESM module, where direct use of require() is not available. This causes the error: "SB_CORE-SERVER_0002 (CriticalPresetLoadError): Storybook failed to load preset" as reported in issue [#7325](https://github.com/QwikDev/qwik/issues/7325).