### PR TITLE
fix: Compatibility issue between Common/ES Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "watch": "yarn workspace storybook-framework-qwik watch",
     "build": "yarn workspace storybook-framework-qwik build",
     "lint-all": "yarn workspaces foreach run fmt.check && yarn workspaces foreach run lint",
-    "storybook": "yarn workspace qwik-app storybook",
+    "storybook": "yarn workspace qwik-lib storybook",
     "fmt-all": "yarn workspaces foreach run fmt",
     "fmt": "prettier --write .",
     "fmt.check": "prettier --check .",

--- a/packages/storybook-framework-qwik/preset.js
+++ b/packages/storybook-framework-qwik/preset.js
@@ -1,2 +1,2 @@
 // This file seems to only be necessary for Windows
-module.exports = require("./dist/preset");
+export * from "./dist/preset.js"

--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -4,10 +4,10 @@ import { qwikDocgen } from "./docs/qwik-docgen.js";
 import { StorybookConfig } from "./types.js";
 import { dirname, join } from "path";
 import { createRequire } from "module";
+import { fileURLToPath } from "url";
 
 const require = createRequire(import.meta.url);
-const wrapForPnP = (input: string) =>
-  dirname(require.resolve(join(input, "package.json")));
+const wrapForPnP = (input: string) => input;
 
 export const core: StorybookConfig["core"] = {
   builder: wrapForPnP("@storybook/builder-vite"),
@@ -54,7 +54,7 @@ export const viteFinal: StorybookConfig["viteFinal"] = async (
 
 export const previewAnnotations: StorybookConfig["previewAnnotations"] = (
   entry = [],
-) => [...entry, require.resolve("storybook-framework-qwik/preview.js")];
+) => [...entry, join(dirname(fileURLToPath(import.meta.url)), "preview.js")];
 
 export const previewHead = (head: string) => {
   return `${head} <script>${QWIK_LOADER}</script>`;

--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -51,7 +51,7 @@ export const viteFinal: StorybookConfig["viteFinal"] = async (
 
 export const previewAnnotations: StorybookConfig["previewAnnotations"] = (
   entry = [],
-) => [...entry, join(dirname(fileURLToPath(import.meta.url)), "preview.js")];
+) => [...entry, join(dirname(fileURLToPath(import.meta.url)), "../preview.js")];
 
 export const previewHead = (head: string) => {
   return `${head} <script>${QWIK_LOADER}</script>`;

--- a/packages/storybook-framework-qwik/src/preset.ts
+++ b/packages/storybook-framework-qwik/src/preset.ts
@@ -6,12 +6,9 @@ import { dirname, join } from "path";
 import { createRequire } from "module";
 import { fileURLToPath } from "url";
 
-const require = createRequire(import.meta.url);
-const wrapForPnP = (input: string) => input;
-
 export const core: StorybookConfig["core"] = {
-  builder: wrapForPnP("@storybook/builder-vite"),
-  renderer: wrapForPnP("storybook-framework-qwik"),
+  builder: "@storybook/builder-vite",
+  renderer: "storybook-framework-qwik",
 };
 
 export const viteFinal: StorybookConfig["viteFinal"] = async (


### PR DESCRIPTION
This PR fix #82.

Changes made:
- Updated `preset.js` to Windows users (like me)
- `previewAnnotations` function now do not relay on require anymore
- `wrapForPnP` function was removed since StoryBook now handle imports by its own
